### PR TITLE
test(modify-yaml): stop the fuzz fixture descending into arrays

### DIFF
--- a/actions/common/modify-yaml/src/modify.fuzz.test.ts
+++ b/actions/common/modify-yaml/src/modify.fuzz.test.ts
@@ -32,6 +32,17 @@ function expectedInference(input: string): string | number | boolean | null {
   return input;
 }
 
+/**
+ * Whether a value can hold the next path segment as a key.
+ *
+ * Arrays are excluded even though `typeof [] === 'object'`: `yaml.stringify` serializes only their
+ * indexed entries, so a string key set on one never reaches the file and the key path under test
+ * would be absent by construction.
+ */
+function canHoldKeys(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 // Helper to create a temp file for fuzzing
 async function withTempFile(content: string, callback: (path: string) => Promise<void>) {
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fuzz-test-'));
@@ -62,7 +73,7 @@ describe('modifyYaml Fuzzing', () => {
           let current = baseObj;
           for (let i = 0; i < pathSegments.length - 1; i++) {
             const segment = pathSegments[i];
-            if (current[segment] === undefined || typeof current[segment] !== 'object' || current[segment] === null) {
+            if (!canHoldKeys(current[segment])) {
               current[segment] = {};
             }
             current = current[segment];


### PR DESCRIPTION
## Problem

`modifyYaml Fuzzing > should safely modify deeply nested YAML structures even with ugly formatting` fails intermittently, e.g. in [run 30894190937](https://github.com/TimSchoenle/actions/actions/runs/30894190937/job/91943059685):

```
Error: Property failed after 24 tests
{ seed: 1544274015, path: "23:1:0:5:5:10:10:10:10", endOnFailure: true }
Counterexample: [{"-":[]},["-"," "],"",""]
Caused by: YamlKeyNotFoundError: Key '-. ' not found in /tmp/fuzz-test-uvrFZO/fuzz.yaml
```

This is a defect in the test fixture, not in `modifyYaml`.

The fixture builds the nested structure for the generated path and treated any non-null `object` as a container for the next segment. `typeof [] === 'object'`, so when the generated `baseObj` already held an array at that segment (`{"-": []}`), the fixture descended into the array and set a string key on it. `yaml.stringify` serializes only an array's indexed entries, so the key never reached the file — and `modifyYaml` then correctly reported the key path as missing.

## Fix

Restrict the container check to plain objects via a named `canHoldKeys` helper, so a segment landing on an array replaces it with `{}` and the constructed key path always survives serialization.

## Verification

- Reproduced locally by pinning `{ seed: 1544274015, path: '23:1:0:5:5:10:10:10:10', endOnFailure: true }`; fails before the change, passes after.
- Stress-ran the property at `numRuns: 20000` (and the sibling primitive-persistence property at `numRuns: 20000`) — clean.
- Full suite: 1577 passed / 116 files. Lint and typecheck clean.

Test-only change, so `test(...)` — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
